### PR TITLE
fix: wrong cursor position after text inserted

### DIFF
--- a/app/src/main/java/com/elliot00/liushu/service/LiushuInputMethodService.kt
+++ b/app/src/main/java/com/elliot00/liushu/service/LiushuInputMethodService.kt
@@ -80,7 +80,7 @@ class LiushuInputMethodService : LifecycleInputMethodService(), ViewModelStoreOw
     }
 
     override fun commitText(text: String) {
-        currentInputConnection.commitText(text, text.length)
+        currentInputConnection.commitText(text, 1)
     }
 
     override fun search(code: String): List<Candidate> {


### PR DESCRIPTION
Android BaseInputConnection commitText(..., int newCursorPosition):

> So a value of 1 will always advance the cursor to the position after the full text being inserted.